### PR TITLE
Redesign, again

### DIFF
--- a/webview_keypad/glyphs.js
+++ b/webview_keypad/glyphs.js
@@ -1,463 +1,555 @@
 const glyphs= 
-{
-  "absolute value": {
-    "glyph": "⌵",
-    "description": "Get the absolute value of a number",
-    "class": "code-font monadic-function-button"
-  },
-  "add": {
-    "glyph": "+",
-    "description": "Add values",
-    "class": "code-font dyadic-function-button"
-  },
-  "assert": {
-    "glyph": "⍤",
-    "description": "Throw an error if a condition is not met",
-    "class": "code-font dyadic-function-button"
-  },
-  "atangent": {
-    "glyph": "∠",
-    "description": "Take the arctangent of two numbers",
-    "class": "code-font dyadic-function-button"
-  },
-  "bind": {
-    "glyph": "'",
-    "description": "Compose two functions",
-    "class": "code-font modifier2-button"
-  },
-  "bits": {
-    "glyph": "⋯",
-    "description": "Encode an array as bits (big-endian)",
-    "class": "code-font monadic-function-button"
-  },
-  "both": {
-    "glyph": "∩",
-    "description": "Call a function on two sets of values",
-    "class": "code-font modifier1-button"
-  },
-  "box": {
-    "glyph": "□",
-    "description": "Turn an array into a box",
-    "class": "code-font monadic-function-button"
-  },
-  "bracket": {
-    "glyph": "⊓",
-    "description": "Call two functions on two distinct sets of values",
-    "class": "code-font modifier2-button"
-  },
-  "break": {
-    "glyph": "⎋",
-    "description": "Break out of a loop",
-    "class": "code-font monadic-function-button"
-  },
-  "call": {
-    "glyph": "!",
-    "description": "Call a function",
-    "class": "code-font variadic-function-button"
-  },
-  "ceiling": {
-    "glyph": "⌈",
-    "description": "Round to the nearest integer towards ∞",
-    "class": "code-font monadic-function-button"
-  },
-  "classify": {
-    "glyph": "⊛",
-    "description": "Assign a unique index to each unique element in an array",
-    "class": "code-font monadic-function-button"
-  },
-  "couple": {
-    "glyph": "⊟",
-    "description": "Combine two arrays as rows of a new array",
-    "class": "code-font dyadic-function-button"
-  },
-  "cross": {
-    "glyph": "⊠",
-    "description": "Apply a function to each combination of rows of two arrays",
-    "class": "code-font modifier1-button"
-  },
-  "deduplicate": {
-    "glyph": "⊝",
-    "description": "Remove duplicate elements from an array",
-    "class": "code-font monadic-function-button"
-  },
-  "deshape": {
-    "glyph": "♭",
-    "description": "Make an array 1-dimensional",
-    "class": "code-font monadic-function-button"
-  },
-  "dip": {
-    "glyph": "⊙",
-    "description": "Temporarily pop the top value off the stack and call a function",
-    "class": "code-font modifier1-button"
-  },
-  "distribute": {
-    "glyph": "∺",
-    "description": "Apply a function to a fixed value and each row of an array",
-    "class": "code-font modifier1-button"
-  },
-  "divide": {
-    "glyph": "÷",
-    "description": "Divide values",
-    "class": "code-font dyadic-function-button"
-  },
-  "drop": {
-    "glyph": "↘",
-    "description": "Drop the first n elements of an array",
-    "class": "code-font dyadic-function-button"
-  },
-  "duplicate": {
+[
+  {
+    "name": "duplicate",
     "glyph": ".",
     "description": "Duplicate the top value on the stack",
     "class": "code-font stack-function-button"
   },
-  "each": {
-    "glyph": "∵",
-    "description": "Apply a function to each element of an array or arrays.",
-    "class": "code-font modifier1-button"
-  },
-  "equals": {
-    "glyph": "=",
-    "description": "Compare for equality",
-    "class": "code-font dyadic-function-button"
-  },
-  "eta": {
-    "glyph": "η",
-    "description": "The number of radians in a quarter circle",
-    "class": "code-font noadic-function-button"
-  },
-  "fall": {
-    "glyph": "⍖",
-    "description": "Get the indices into an array if it were sorted descending",
-    "class": "code-font monadic-function-button"
-  },
-  "fill": {
-    "glyph": "⬚",
-    "description": "Set the fill value for a function",
-    "class": "code-font modifier2-button"
-  },
-  "find": {
-    "glyph": "⌕",
-    "description": "Find the occurences of one array in another",
-    "class": "code-font dyadic-function-button"
-  },
-  "first": {
-    "glyph": "⊢",
-    "description": "Get the first row of an array",
-    "class": "code-font monadic-function-button"
-  },
-  "flip": {
-    "glyph": "∶",
-    "description": "Swap the top two values on the stack",
-    "class": "code-font stack-function-button"
-  },
-  "floor": {
-    "glyph": "⌊",
-    "description": "Round to the nearest integer towards ¯∞",
-    "class": "code-font monadic-function-button"
-  },
-  "fold": {
-    "glyph": "∧",
-    "description": "Apply a reducing function to an array with an initial value",
-    "class": "code-font modifier1-button"
-  },
-  "fork": {
-    "glyph": "⊃",
-    "description": "Call two functions on the same values",
-    "class": "code-font modifier2-button"
-  },
-  "gap": {
-    "glyph": "⋅",
-    "description": "Discard the top stack value then call a function",
-    "class": "code-font modifier1-button"
-  },
-  "greater or equal": {
-    "glyph": "≥",
-    "description": "Compare for greater than or equal",
-    "class": "code-font dyadic-function-button"
-  },
-  "greater than": {
-    "glyph": ">",
-    "description": "Compare for greater than",
-    "class": "code-font dyadic-function-button"
-  },
-  "group": {
-    "glyph": "⊕",
-    "description": "Group elements of an array into buckets by index",
-    "class": "code-font modifier1-button"
-  },
-  "identity": {
-    "glyph": "∘",
-    "description": "Do nothing",
-    "class": "code-font stack-function-button"
-  },
-  "if": {
-    "glyph": "?",
-    "description": "Call one of two functions based on a condition",
-    "class": "code-font modifier2-button"
-  },
-  "indexof": {
-    "glyph": "⊗",
-    "description": "Find the index of each row of one array in another",
-    "class": "code-font dyadic-function-button"
-  },
-  "infinity": {
-    "glyph": "∞",
-    "description": "The biggest number",
-    "class": "code-font noadic-function-button"
-  },
-  "invert": {
-    "glyph": "⍘",
-    "description": "Invert the behavior of a function",
-    "class": "code-font modifier1-button"
-  },
-  "join": {
-    "glyph": "⊂",
-    "description": "Append two arrays end-to-end",
-    "class": "code-font dyadic-function-button"
-  },
-  "keep": {
-    "glyph": "▽",
-    "description": "Discard or copy some rows of an array",
-    "class": "code-font dyadic-function-button"
-  },
-  "length": {
-    "glyph": "⧻",
-    "description": "Get the number of rows in an array",
-    "class": "code-font monadic-function-button"
-  },
-  "less or equal": {
-    "glyph": "≤",
-    "description": "Compare for less than or equal",
-    "class": "code-font dyadic-function-button"
-  },
-  "less than": {
-    "glyph": "<",
-    "description": "Compare for less than",
-    "class": "code-font dyadic-function-button"
-  },
-  "level": {
-    "glyph": "⍚",
-    "description": "Apply a function at a different array depth",
-    "class": "code-font modifier2-button"
-  },
-  "logarithm": {
-    "glyph": "ₙ",
-    "description": "Get the based logarithm of a number",
-    "class": "code-font dyadic-function-button"
-  },
-  "match": {
-    "glyph": "≅",
-    "description": "Check if two arrays are exactly the same",
-    "class": "code-font dyadic-function-button"
-  },
-  "maximum": {
-    "glyph": "↥",
-    "description": "Take the maximum of two arrays",
-    "class": "code-font dyadic-function-button"
-  },
-  "member": {
-    "glyph": "∊",
-    "description": "Check if each row of one array exists in another",
-    "class": "code-font dyadic-function-button"
-  },
-  "minimum": {
-    "glyph": "↧",
-    "description": "Take the minimum of two arrays",
-    "class": "code-font dyadic-function-button"
-  },
-  "modulus": {
-    "glyph": "◿",
-    "description": "Modulo values",
-    "class": "code-font dyadic-function-button"
-  },
-  "multiply": {
-    "glyph": "×",
-    "description": "Multiply values",
-    "class": "code-font dyadic-function-button"
-  },
-  "negate": {
-    "glyph": "¯",
-    "description": "Negate a number",
-    "class": "code-font monadic-function-button"
-  },
-  "not": {
-    "glyph": "¬",
-    "description": "Logical not",
-    "class": "code-font monadic-function-button"
-  },
-  "not equals": {
-    "glyph": "≠",
-    "description": "Compare for inequality",
-    "class": "code-font dyadic-function-button"
-  },
-  "over": {
+  {
+    "name": "over",
     "glyph": ",",
     "description": "Duplicate the second-to-top value to the top of the stack",
     "class": "code-font stack-function-button"
   },
-  "partition": {
-    "glyph": "⊜",
-    "description": "Group elements of an array into buckets by sequential keys",
-    "class": "code-font modifier1-button"
+  {
+    "name": "flip",
+    "glyph": "∶",
+    "description": "Swap the top two values on the stack",
+    "class": "code-font stack-function-button"
   },
-  "pi": {
-    "glyph": "π",
-    "description": "The ratio of a circle's circumference to its diameter",
-    "class": "code-font noadic-function-button"
-  },
-  "pick": {
-    "glyph": "⊡",
-    "description": "Index a row or elements from an array",
-    "class": "code-font dyadic-function-button"
-  },
-  "pop": {
+  {
+    "name": "pop",
     "glyph": ";",
     "description": "Discard the top stack value",
     "class": "code-font stack-function-button"
   },
-  "power": {
-    "glyph": "ⁿ",
-    "description": "Raise a value to a power",
-    "class": "code-font dyadic-function-button"
+  {
+    "name": "identity",
+    "glyph": "∘",
+    "description": "Do nothing",
+    "class": "code-font stack-function-button"
   },
-  "random": {
-    "glyph": "⚂",
-    "description": "Generate a random number between 0 and 1",
-    "class": "code-font noadic-function-button"
-  },
-  "range": {
-    "glyph": "⇡",
-    "description": "Make an array of all natural numbers less than a number",
+  {
+    "name": "not",
+    "glyph": "¬",
+    "description": "Logical not",
     "class": "code-font monadic-function-button"
   },
-  "recur": {
-    "glyph": "↬",
-    "description": "Call a function recursively",
-    "class": "code-font monadic-function-button"
-  },
-  "reduce": {
-    "glyph": "/",
-    "description": "Apply a reducing function to an array",
-    "class": "code-font modifier1-button"
-  },
-  "repeat": {
-    "glyph": "⍥",
-    "description": "Repeat a function a number of times",
-    "class": "code-font modifier1-button"
-  },
-  "reshape": {
-    "glyph": "↯",
-    "description": "Change the shape of an array",
-    "class": "code-font dyadic-function-button"
-  },
-  "reverse": {
-    "glyph": "⇌",
-    "description": "Reverse the rows of an array",
-    "class": "code-font monadic-function-button"
-  },
-  "rise": {
-    "glyph": "⍏",
-    "description": "Get the indices into an array if it were sorted ascending",
-    "class": "code-font monadic-function-button"
-  },
-  "rotate": {
-    "glyph": "↻",
-    "description": "Rotate the elements of an array by n",
-    "class": "code-font dyadic-function-button"
-  },
-  "round": {
-    "glyph": "⁅",
-    "description": "Round to the nearest integer",
-    "class": "code-font monadic-function-button"
-  },
-  "rows": {
-    "glyph": "≡",
-    "description": "Apply a function to each row of an array or arrays",
-    "class": "code-font modifier1-button"
-  },
-  "scan": {
-    "glyph": "\\",
-    "description": "Reduce, but keep intermediate values",
-    "class": "code-font modifier1-button"
-  },
-  "select": {
-    "glyph": "⊏",
-    "description": "Select multiple rows from an array",
-    "class": "code-font dyadic-function-button"
-  },
-  "shape": {
-    "glyph": "△",
-    "description": "Get the dimensions of an array",
-    "class": "code-font monadic-function-button"
-  },
-  "sign": {
+  {
+    "name": "sign",
     "glyph": "±",
     "description": "Numerical sign (1, ¯1, or 0)",
     "class": "code-font monadic-function-button"
   },
-  "sine": {
-    "glyph": "○",
-    "description": "Get the sine of a number",
+  {
+    "name": "negate",
+    "glyph": "¯",
+    "description": "Negate a number",
     "class": "code-font monadic-function-button"
   },
-  "sqrt": {
+  {
+    "name": "absolute value",
+    "glyph": "⌵",
+    "description": "Get the absolute value of a number",
+    "class": "code-font monadic-function-button"
+  },
+  {
+    "name": "sqrt",
     "glyph": "√",
     "description": "Take the square root of a number",
     "class": "code-font monadic-function-button"
   },
-  "subtract": {
+  {
+    "name": "sine",
+    "glyph": "○",
+    "description": "Get the sine of a number",
+    "class": "code-font monadic-function-button"
+  },
+  {
+    "name": "floor",
+    "glyph": "⌊",
+    "description": "Round to the nearest integer towards ¯∞",
+    "class": "code-font monadic-function-button"
+  },
+  {
+    "name": "ceiling",
+    "glyph": "⌈",
+    "description": "Round to the nearest integer towards ∞",
+    "class": "code-font monadic-function-button"
+  },
+  {
+    "name": "round",
+    "glyph": "⁅",
+    "description": "Round to the nearest integer",
+    "class": "code-font monadic-function-button"
+  },
+  {
+    "name": "equals",
+    "glyph": "=",
+    "description": "Compare for equality",
+    "class": "code-font dyadic-function-button"
+  },
+  {
+    "name": "not equals",
+    "glyph": "≠",
+    "description": "Compare for inequality",
+    "class": "code-font dyadic-function-button"
+  },
+  {
+    "name": "less than",
+    "glyph": "<",
+    "description": "Compare for less than",
+    "class": "code-font dyadic-function-button"
+  },
+  {
+    "name": "less or equal",
+    "glyph": "≤",
+    "description": "Compare for less than or equal",
+    "class": "code-font dyadic-function-button"
+  },
+  {
+    "name": "greater than",
+    "glyph": ">",
+    "description": "Compare for greater than",
+    "class": "code-font dyadic-function-button"
+  },
+  {
+    "name": "greater or equal",
+    "glyph": "≥",
+    "description": "Compare for greater than or equal",
+    "class": "code-font dyadic-function-button"
+  },
+  {
+    "name": "add",
+    "glyph": "+",
+    "description": "Add values",
+    "class": "code-font dyadic-function-button"
+  },
+  {
+    "name": "subtract",
     "glyph": "-",
     "description": "Subtract values",
     "class": "code-font dyadic-function-button"
   },
-  "table": {
-    "glyph": "⊞",
-    "description": "Apply a function to each combination of elements of two arrays",
-    "class": "code-font modifier1-button"
-  },
-  "take": {
-    "glyph": "↙",
-    "description": "Take the first n elements of an array",
+  {
+    "name": "multiply",
+    "glyph": "×",
+    "description": "Multiply values",
     "class": "code-font dyadic-function-button"
   },
-  "tau": {
-    "glyph": "τ",
-    "description": "The ratio of a circle's circumference to its radius",
-    "class": "code-font noadic-function-button"
+  {
+    "name": "divide",
+    "glyph": "÷",
+    "description": "Divide values",
+    "class": "code-font dyadic-function-button"
   },
-  "trace": {
-    "glyph": "~",
-    "description": "Debug print the top value on the stack without popping it",
-    "class": "code-font stack-function-button"
+  {
+    "name": "modulus",
+    "glyph": "◿",
+    "description": "Modulo values",
+    "class": "code-font dyadic-function-button"
   },
-  "transpose": {
+  {
+    "name": "power",
+    "glyph": "ⁿ",
+    "description": "Raise a value to a power",
+    "class": "code-font dyadic-function-button"
+  },
+  {
+    "name": "logarithm",
+    "glyph": "ₙ",
+    "description": "Get the based logarithm of a number",
+    "class": "code-font dyadic-function-button"
+  },
+  {
+    "name": "minimum",
+    "glyph": "↧",
+    "description": "Take the minimum of two arrays",
+    "class": "code-font dyadic-function-button"
+  },
+  {
+    "name": "maximum",
+    "glyph": "↥",
+    "description": "Take the maximum of two arrays",
+    "class": "code-font dyadic-function-button"
+  },
+  {
+    "name": "atangent",
+    "glyph": "∠",
+    "description": "Take the arctangent of two numbers",
+    "class": "code-font dyadic-function-button"
+  },
+  {
+    "name": "length",
+    "glyph": "⧻",
+    "description": "Get the number of rows in an array",
+    "class": "code-font monadic-function-button"
+  },
+  {
+    "name": "shape",
+    "glyph": "△",
+    "description": "Get the dimensions of an array",
+    "class": "code-font monadic-function-button"
+  },
+  {
+    "name": "range",
+    "glyph": "⇡",
+    "description": "Make an array of all natural numbers less than a number",
+    "class": "code-font monadic-function-button"
+  },
+  {
+    "name": "first",
+    "glyph": "⊢",
+    "description": "Get the first row of an array",
+    "class": "code-font monadic-function-button"
+  },
+  {
+    "name": "reverse",
+    "glyph": "⇌",
+    "description": "Reverse the rows of an array",
+    "class": "code-font monadic-function-button"
+  },
+  {
+    "name": "deshape",
+    "glyph": "♭",
+    "description": "Make an array 1-dimensional",
+    "class": "code-font monadic-function-button"
+  },
+  {
+    "name": "bits",
+    "glyph": "⋯",
+    "description": "Encode an array as bits (big-endian)",
+    "class": "code-font monadic-function-button"
+  },
+  {
+    "name": "transpose",
     "glyph": "⍉",
     "description": "Rotate the shape of an array",
     "class": "code-font monadic-function-button trans"
   },
-  "try": {
-    "glyph": "⍣",
-    "description": "Call a function and catch errors",
-    "class": "code-font modifier2-button"
-  },
-  "unbox": {
-    "glyph": "⊔",
-    "description": "Take an array out of a box",
+  {
+    "name": "rise",
+    "glyph": "⍏",
+    "description": "Get the indices into an array if it were sorted ascending",
     "class": "code-font monadic-function-button"
   },
-  "under": {
-    "glyph": "⍜",
-    "description": "Apply a function under another",
-    "class": "code-font modifier2-button"
+  {
+    "name": "fall",
+    "glyph": "⍖",
+    "description": "Get the indices into an array if it were sorted descending",
+    "class": "code-font monadic-function-button"
   },
-  "where": {
+  {
+    "name": "where",
     "glyph": "⊚",
     "description": "Get indices where array values are not equal to zero",
     "class": "code-font monadic-function-button"
   },
-  "windows": {
+  {
+    "name": "classify",
+    "glyph": "⊛",
+    "description": "Assign a unique index to each unique element in an array",
+    "class": "code-font monadic-function-button"
+  },
+  {
+    "name": "deduplicate",
+    "glyph": "⊝",
+    "description": "Remove duplicate elements from an array",
+    "class": "code-font monadic-function-button"
+  },
+  {
+    "name": "box",
+    "glyph": "□",
+    "description": "Turn an array into a box",
+    "class": "code-font monadic-function-button"
+  },
+  {
+    "name": "unbox",
+    "glyph": "⊔",
+    "description": "Take an array out of a box",
+    "class": "code-font monadic-function-button"
+  },
+  {
+    "name": "match",
+    "glyph": "≅",
+    "description": "Check if two arrays are exactly the same",
+    "class": "code-font dyadic-function-button"
+  },
+  {
+    "name": "couple",
+    "glyph": "⊟",
+    "description": "Combine two arrays as rows of a new array",
+    "class": "code-font dyadic-function-button"
+  },
+  {
+    "name": "join",
+    "glyph": "⊂",
+    "description": "Append two arrays end-to-end",
+    "class": "code-font dyadic-function-button"
+  },
+  {
+    "name": "select",
+    "glyph": "⊏",
+    "description": "Select multiple rows from an array",
+    "class": "code-font dyadic-function-button"
+  },
+  {
+    "name": "pick",
+    "glyph": "⊡",
+    "description": "Index a row or elements from an array",
+    "class": "code-font dyadic-function-button"
+  },
+  {
+    "name": "reshape",
+    "glyph": "↯",
+    "description": "Change the shape of an array",
+    "class": "code-font dyadic-function-button"
+  },
+  {
+    "name": "take",
+    "glyph": "↙",
+    "description": "Take the first n elements of an array",
+    "class": "code-font dyadic-function-button"
+  },
+  {
+    "name": "drop",
+    "glyph": "↘",
+    "description": "Drop the first n elements of an array",
+    "class": "code-font dyadic-function-button"
+  },
+  {
+    "name": "rotate",
+    "glyph": "↻",
+    "description": "Rotate the elements of an array by n",
+    "class": "code-font dyadic-function-button"
+  },
+  {
+    "name": "windows",
     "glyph": "◫",
     "description": "The n-wise windows of an array",
     "class": "code-font dyadic-function-button"
+  },
+  {
+    "name": "keep",
+    "glyph": "▽",
+    "description": "Discard or copy some rows of an array",
+    "class": "code-font dyadic-function-button"
+  },
+  {
+    "name": "find",
+    "glyph": "⌕",
+    "description": "Find the occurences of one array in another",
+    "class": "code-font dyadic-function-button"
+  },
+  {
+    "name": "member",
+    "glyph": "∊",
+    "description": "Check if each row of one array exists in another",
+    "class": "code-font dyadic-function-button"
+  },
+  {
+    "name": "indexof",
+    "glyph": "⊗",
+    "description": "Find the index of each row of one array in another",
+    "class": "code-font dyadic-function-button"
+  },
+  {
+    "name": "reduce",
+    "glyph": "/",
+    "description": "Apply a reducing function to an array",
+    "class": "code-font modifier1-button"
+  },
+  {
+    "name": "fold",
+    "glyph": "∧",
+    "description": "Apply a reducing function to an array with an initial value",
+    "class": "code-font modifier1-button"
+  },
+  {
+    "name": "scan",
+    "glyph": "\\",
+    "description": "Reduce, but keep intermediate values",
+    "class": "code-font modifier1-button"
+  },
+  {
+    "name": "each",
+    "glyph": "∵",
+    "description": "Apply a function to each element of an array or arrays.",
+    "class": "code-font modifier1-button"
+  },
+  {
+    "name": "rows",
+    "glyph": "≡",
+    "description": "Apply a function to each row of an array or arrays",
+    "class": "code-font modifier1-button"
+  },
+  {
+    "name": "distribute",
+    "glyph": "∺",
+    "description": "Apply a function to a fixed value and each row of an array",
+    "class": "code-font modifier1-button"
+  },
+  {
+    "name": "table",
+    "glyph": "⊞",
+    "description": "Apply a function to each combination of elements of two arrays",
+    "class": "code-font modifier1-button"
+  },
+  {
+    "name": "cross",
+    "glyph": "⊠",
+    "description": "Apply a function to each combination of rows of two arrays",
+    "class": "code-font modifier1-button"
+  },
+  {
+    "name": "repeat",
+    "glyph": "⍥",
+    "description": "Repeat a function a number of times",
+    "class": "code-font modifier1-button"
+  },
+  {
+    "name": "group",
+    "glyph": "⊕",
+    "description": "Group elements of an array into buckets by index",
+    "class": "code-font modifier1-button"
+  },
+  {
+    "name": "partition",
+    "glyph": "⊜",
+    "description": "Group elements of an array into buckets by sequential keys",
+    "class": "code-font modifier1-button"
+  },
+  {
+    "name": "both",
+    "glyph": "∩",
+    "description": "Call a function on two sets of values",
+    "class": "code-font modifier1-button"
+  },
+  {
+    "name": "bracket",
+    "glyph": "⊓",
+    "description": "Call two functions on two distinct sets of values",
+    "class": "code-font modifier2-button"
+  },
+  {
+    "name": "fork",
+    "glyph": "⊃",
+    "description": "Call two functions on the same values",
+    "class": "code-font modifier2-button"
+  },
+  {
+    "name": "dip",
+    "glyph": "⊙",
+    "description": "Temporarily pop the top value off the stack and call a function",
+    "class": "code-font modifier1-button"
+  },
+  {
+    "name": "gap",
+    "glyph": "⋅",
+    "description": "Discard the top stack value then call a function",
+    "class": "code-font modifier1-button"
+  },
+  {
+    "name": "invert",
+    "glyph": "⍘",
+    "description": "Invert the behavior of a function",
+    "class": "code-font modifier1-button"
+  },
+  {
+    "name": "under",
+    "glyph": "⍜",
+    "description": "Apply a function under another",
+    "class": "code-font modifier2-button"
+  },
+  {
+    "name": "level",
+    "glyph": "⍚",
+    "description": "Apply a function at a different array depth",
+    "class": "code-font modifier2-button"
+  },
+  {
+    "name": "fill",
+    "glyph": "⬚",
+    "description": "Set the fill value for a function",
+    "class": "code-font modifier2-button"
+  },
+  {
+    "name": "bind",
+    "glyph": "'",
+    "description": "Compose two functions",
+    "class": "code-font modifier2-button"
+  },
+  {
+    "name": "if",
+    "glyph": "?",
+    "description": "Call one of two functions based on a condition",
+    "class": "code-font modifier2-button"
+  },
+  {
+    "name": "try",
+    "glyph": "⍣",
+    "description": "Call a function and catch errors",
+    "class": "code-font modifier2-button"
+  },
+  {
+    "name": "assert",
+    "glyph": "⍤",
+    "description": "Throw an error if a condition is not met",
+    "class": "code-font dyadic-function-button"
+  },
+  {
+    "name": "call",
+    "glyph": "!",
+    "description": "Call a function",
+    "class": "code-font variadic-function-button"
+  },
+  {
+    "name": "break",
+    "glyph": "⎋",
+    "description": "Break out of a loop",
+    "class": "code-font monadic-function-button"
+  },
+  {
+    "name": "recur",
+    "glyph": "↬",
+    "description": "Call a function recursively",
+    "class": "code-font monadic-function-button"
+  },
+  {
+    "name": "random",
+    "glyph": "⚂",
+    "description": "Generate a random number between 0 and 1",
+    "class": "code-font noadic-function-button"
+  },
+  {
+    "name": "eta",
+    "glyph": "η",
+    "description": "The number of radians in a quarter circle",
+    "class": "code-font noadic-function-button"
+  },
+  {
+    "name": "pi",
+    "glyph": "π",
+    "description": "The ratio of a circle's circumference to its diameter",
+    "class": "code-font noadic-function-button"
+  },
+  {
+    "name": "tau",
+    "glyph": "τ",
+    "description": "The ratio of a circle's circumference to its radius",
+    "class": "code-font noadic-function-button"
+  },
+  {
+    "name": "infinity",
+    "glyph": "∞",
+    "description": "The biggest number",
+    "class": "code-font noadic-function-button"
+  },
+  {
+    "name": "trace",
+    "glyph": "~",
+    "description": "Debug print the top value on the stack without popping it",
+    "class": "code-font stack-function-button"
   }
-}
+]

--- a/webview_keypad/glyphs.js
+++ b/webview_keypad/glyphs.js
@@ -1,632 +1,463 @@
-const glyphs = [
-    {
-        "glyph": ".",
-        "title": "duplicate",
-        "css_class": "stack-function-button",
-        "color": "rgb(209, 218, 236)"
-    },
-    {
-        "glyph": ",",
-        "title": "over",
-        "css_class": "stack-function-button",
-        "color": "rgb(209, 218, 236)"
-    },
-    {
-        "glyph": "∶",
-        "title": "(:) flip",
-        "css_class": "stack-function-button",
-        "color": "rgb(209, 218, 236)"
-    },
-    {
-        "glyph": ";",
-        "title": "pop",
-        "css_class": "stack-function-button",
-        "color": "rgb(209, 218, 236)"
-    },
-    {
-        "glyph": "∘",
-        "title": "identity",
-        "css_class": "stack-function-button",
-        "color": "rgb(209, 218, 236)"
-    },
-    {
-        "glyph": "¬",
-        "title": "not",
-        "css_class": "monadic-function-button",
-        "color": "rgb(149, 209, 106)"
-    },
-    {
-        "glyph": "±",
-        "title": "sign",
-        "css_class": "monadic-function-button",
-        "color": "rgb(149, 209, 106)"
-    },
-    {
-        "glyph": "¯",
-        "title": "(`) negate",
-        "css_class": "monadic-function-button",
-        "color": "rgb(149, 209, 106)"
-    },
-    {
-        "glyph": "⌵",
-        "title": "absolute value",
-        "css_class": "monadic-function-button",
-        "color": "rgb(149, 209, 106)"
-    },
-    {
-        "glyph": "√",
-        "title": "sqrt",
-        "css_class": "monadic-function-button",
-        "color": "rgb(149, 209, 106)"
-    },
-    {
-        "glyph": "○",
-        "title": "sine",
-        "css_class": "monadic-function-button",
-        "color": "rgb(149, 209, 106)"
-    },
-    {
-        "glyph": "⌊",
-        "title": "floor",
-        "css_class": "monadic-function-button",
-        "color": "rgb(149, 209, 106)"
-    },
-    {
-        "glyph": "⌈",
-        "title": "ceiling",
-        "css_class": "monadic-function-button",
-        "color": "rgb(149, 209, 106)"
-    },
-    {
-        "glyph": "⁅",
-        "title": "round",
-        "css_class": "monadic-function-button",
-        "color": "rgb(149, 209, 106)"
-    },
-    {
-        "glyph": "=",
-        "title": "(=) equals",
-        "css_class": "dyadic-function-button",
-        "color": "rgb(84, 176, 252)"
-    },
-    {
-        "glyph": "≠",
-        "title": "(!=) not equals",
-        "css_class": "dyadic-function-button",
-        "color": "rgb(84, 176, 252)"
-    },
-    {
-        "glyph": "<",
-        "title": "less than",
-        "css_class": "dyadic-function-button",
-        "color": "rgb(84, 176, 252)"
-    },
-    {
-        "glyph": "≤",
-        "title": "(<=) less or equal",
-        "css_class": "dyadic-function-button",
-        "color": "rgb(84, 176, 252)"
-    },
-    {
-        "glyph": ">",
-        "title": "greater than",
-        "css_class": "dyadic-function-button",
-        "color": "rgb(84, 176, 252)"
-    },
-    {
-        "glyph": "≥",
-        "title": "(>=) greater or equal",
-        "css_class": "dyadic-function-button",
-        "color": "rgb(84, 176, 252)"
-    },
-    {
-        "glyph": "+",
-        "title": "add",
-        "css_class": "dyadic-function-button",
-        "color": "rgb(84, 176, 252)"
-    },
-    {
-        "glyph": "-",
-        "title": "subtract",
-        "css_class": "dyadic-function-button",
-        "color": "rgb(84, 176, 252)"
-    },
-    {
-        "glyph": "×",
-        "title": "(*) multiply",
-        "css_class": "dyadic-function-button",
-        "color": "rgb(84, 176, 252)"
-    },
-    {
-        "glyph": "÷",
-        "title": "(%) divide",
-        "css_class": "dyadic-function-button",
-        "color": "rgb(84, 176, 252)"
-    },
-    {
-        "glyph": "◿",
-        "title": "modulus",
-        "css_class": "dyadic-function-button",
-        "color": "rgb(84, 176, 252)"
-    },
-    {
-        "glyph": "ⁿ",
-        "title": "power",
-        "css_class": "dyadic-function-button",
-        "color": "rgb(84, 176, 252)"
-    },
-    {
-        "glyph": "ₙ",
-        "title": "logarithm",
-        "css_class": "dyadic-function-button",
-        "color": "rgb(84, 176, 252)"
-    },
-    {
-        "glyph": "↧",
-        "title": "minimum",
-        "css_class": "dyadic-function-button",
-        "color": "rgb(84, 176, 252)"
-    },
-    {
-        "glyph": "↥",
-        "title": "maximum",
-        "css_class": "dyadic-function-button",
-        "color": "rgb(84, 176, 252)"
-    },
-    {
-        "glyph": "∠",
-        "title": "atangent",
-        "css_class": "dyadic-function-button",
-        "color": "rgb(84, 176, 252)"
-    },
-    {
-        "glyph": "⧻",
-        "title": "length",
-        "css_class": "monadic-function-button",
-        "color": "rgb(149, 209, 106)"
-    },
-    {
-        "glyph": "△",
-        "title": "shape",
-        "css_class": "monadic-function-button",
-        "color": "rgb(149, 209, 106)"
-    },
-    {
-        "glyph": "⇡",
-        "title": "range",
-        "css_class": "monadic-function-button",
-        "color": "rgb(149, 209, 106)"
-    },
-    {
-        "glyph": "⊢",
-        "title": "first",
-        "css_class": "monadic-function-button",
-        "color": "rgb(149, 209, 106)"
-    },
-    {
-        "glyph": "⇌",
-        "title": "reverse",
-        "css_class": "monadic-function-button",
-        "color": "rgb(149, 209, 106)"
-    },
-    {
-        "glyph": "♭",
-        "title": "deshape",
-        "css_class": "monadic-function-button",
-        "color": "rgb(149, 209, 106)"
-    },
-    {
-        "glyph": "⋯",
-        "title": "bits",
-        "css_class": "monadic-function-button",
-        "color": "rgb(149, 209, 106)"
-    },
-    {
-        "glyph": "⍉",
-        "title": "transpose",
-        "css_class": "trans",
-        "color": "rgb(149, 209, 106)"
-    },
-    {
-        "glyph": "⍏",
-        "title": "rise",
-        "css_class": "monadic-function-button",
-        "color": "rgb(149, 209, 106)"
-    },
-    {
-        "glyph": "⍖",
-        "title": "fall",
-        "css_class": "monadic-function-button",
-        "color": "rgb(149, 209, 106)"
-    },
-    {
-        "glyph": "⊛",
-        "title": "classify",
-        "css_class": "monadic-function-button",
-        "color": "rgb(149, 209, 106)"
-    },
-    {
-        "glyph": "⊝",
-        "title": "deduplicate",
-        "css_class": "monadic-function-button",
-        "color": "rgb(149, 209, 106)"
-    },
-    {
-        "glyph": "□",
-        "title": "box",
-        "css_class": "monadic-function-button",
-        "color": "rgb(149, 209, 106)"
-    },
-    {
-        "glyph": "⊔",
-        "title": "unbox",
-        "css_class": "monadic-function-button",
-        "color": "rgb(149, 209, 106)"
-    },
-    {
-        "glyph": "≅",
-        "title": "match",
-        "css_class": "dyadic-function-button",
-        "color": "rgb(84, 176, 252)"
-    },
-    {
-        "glyph": "⊟",
-        "title": "couple",
-        "css_class": "dyadic-function-button",
-        "color": "rgb(84, 176, 252)"
-    },
-    {
-        "glyph": "⊂",
-        "title": "join",
-        "css_class": "dyadic-function-button",
-        "color": "rgb(84, 176, 252)"
-    },
-    {
-        "glyph": "⊏",
-        "title": "select",
-        "css_class": "dyadic-function-button",
-        "color": "rgb(84, 176, 252)"
-    },
-    {
-        "glyph": "⊡",
-        "title": "pick",
-        "css_class": "dyadic-function-button",
-        "color": "rgb(84, 176, 252)"
-    },
-    {
-        "glyph": "↯",
-        "title": "reshape",
-        "css_class": "dyadic-function-button",
-        "color": "rgb(84, 176, 252)"
-    },
-    {
-        "glyph": "↙",
-        "title": "take",
-        "css_class": "dyadic-function-button",
-        "color": "rgb(84, 176, 252)"
-    },
-    {
-        "glyph": "↘",
-        "title": "drop",
-        "css_class": "dyadic-function-button",
-        "color": "rgb(84, 176, 252)"
-    },
-    {
-        "glyph": "↻",
-        "title": "rotate",
-        "css_class": "dyadic-function-button",
-        "color": "rgb(84, 176, 252)"
-    },
-    {
-        "glyph": "◫",
-        "title": "windows",
-        "css_class": "dyadic-function-button",
-        "color": "rgb(84, 176, 252)"
-    },
-    {
-        "glyph": "▽",
-        "title": "keep",
-        "css_class": "dyadic-function-button",
-        "color": "rgb(84, 176, 252)"
-    },
-    {
-        "glyph": "⌕",
-        "title": "find",
-        "css_class": "dyadic-function-button",
-        "color": "rgb(84, 176, 252)"
-    },
-    {
-        "glyph": "∊",
-        "title": "member",
-        "css_class": "dyadic-function-button",
-        "color": "rgb(84, 176, 252)"
-    },
-    {
-        "glyph": "⊗",
-        "title": "indexof",
-        "css_class": "dyadic-function-button",
-        "color": "rgb(84, 176, 252)"
-    },
-    {
-        "glyph": "/",
-        "title": "reduce",
-        "css_class": "modifier1-button",
-        "color": "rgb(240, 195, 111)"
-    },
-    {
-        "glyph": "∧",
-        "title": "fold",
-        "css_class": "modifier1-button",
-        "color": "rgb(240, 195, 111)"
-    },
-    {
-        "glyph": "\\",
-        "title": "scan",
-        "css_class": "modifier1-button",
-        "color": "rgb(240, 195, 111)"
-    },
-    {
-        "glyph": "∵",
-        "title": "each",
-        "css_class": "modifier1-button",
-        "color": "rgb(240, 195, 111)"
-    },
-    {
-        "glyph": "≡",
-        "title": "rows",
-        "css_class": "modifier1-button",
-        "color": "rgb(240, 195, 111)"
-    },
-    {
-        "glyph": "∺",
-        "title": "distribute",
-        "css_class": "modifier1-button",
-        "color": "rgb(240, 195, 111)"
-    },
-    {
-        "glyph": "⊞",
-        "title": "table",
-        "css_class": "modifier1-button",
-        "color": "rgb(240, 195, 111)"
-    },
-    {
-        "glyph": "⊠",
-        "title": "cross",
-        "css_class": "modifier1-button",
-        "color": "rgb(240, 195, 111)"
-    },
-    {
-        "glyph": "⍥",
-        "title": "repeat",
-        "css_class": "modifier1-button",
-        "color": "rgb(240, 195, 111)"
-    },
-    {
-        "glyph": "⊕",
-        "title": "group",
-        "css_class": "modifier1-button",
-        "color": "rgb(240, 195, 111)"
-    },
-    {
-        "glyph": "⊜",
-        "title": "partition",
-        "css_class": "modifier1-button",
-        "color": "rgb(240, 195, 111)"
-    },
-    {
-        "glyph": "∩",
-        "title": "both",
-        "css_class": "modifier1-button",
-        "color": "rgb(240, 195, 111)"
-    },
-    {
-        "glyph": "⊓",
-        "title": "bracket",
-        "css_class": "modifier2-button",
-        "color": "rgb(204, 107, 233)"
-    },
-    {
-        "glyph": "⊃",
-        "title": "fork",
-        "css_class": "modifier2-button",
-        "color": "rgb(204, 107, 233)"
-    },
-    {
-        "glyph": "⊙",
-        "title": "dip",
-        "css_class": "modifier1-button",
-        "color": "rgb(240, 195, 111)"
-    },
-    {
-        "glyph": "⋅",
-        "title": "gap",
-        "css_class": "modifier1-button",
-        "color": "rgb(240, 195, 111)"
-    },
-    {
-        "glyph": "⍘",
-        "title": "invert",
-        "css_class": "modifier1-button",
-        "color": "rgb(240, 195, 111)"
-    },
-    {
-        "glyph": "⍜",
-        "title": "under",
-        "css_class": "modifier2-button",
-        "color": "rgb(204, 107, 233)"
-    },
-    {
-        "glyph": "⍚",
-        "title": "level",
-        "css_class": "modifier2-button",
-        "color": "rgb(204, 107, 233)"
-    },
-    {
-        "glyph": "⬚",
-        "title": "fill",
-        "css_class": "modifier2-button",
-        "color": "rgb(204, 107, 233)"
-    },
-    {
-        "glyph": "'",
-        "title": "bind",
-        "css_class": "modifier2-button",
-        "color": "rgb(204, 107, 233)"
-    },
-    {
-        "glyph": "?",
-        "title": "if",
-        "css_class": "modifier2-button",
-        "color": "rgb(204, 107, 233)"
-    },
-    {
-        "glyph": "⍣",
-        "title": "try",
-        "css_class": "modifier2-button",
-        "color": "rgb(204, 107, 233)"
-    },
-    {
-        "glyph": "⍤",
-        "title": "assert",
-        "css_class": "dyadic-function-button",
-        "color": "rgb(84, 176, 252)"
-    },
-    {
-        "glyph": "↰",
-        "title": "spawn",
-        "css_class": "modifier1-button",
-        "color": "rgb(240, 195, 111)"
-    },
-    {
-        "glyph": "↲",
-        "title": "wait",
-        "css_class": "monadic-function-button",
-        "color": "rgb(149, 209, 106)"
-    },
-    {
-        "glyph": "!",
-        "title": "call",
-        "css_class": "variadic-function-button",
-        "color": "rgb(209, 218, 236)"
-    },
-    {
-        "glyph": "⎋",
-        "title": "break",
-        "css_class": "monadic-function-button",
-        "color": "rgb(149, 209, 106)"
-    },
-    {
-        "glyph": "↬",
-        "title": "recur",
-        "css_class": "monadic-function-button",
-        "color": "rgb(149, 209, 106)"
-    },
-    {
-        "glyph": "⚂",
-        "title": "random",
-        "css_class": "noadic-function-button",
-        "color": "rgb(237, 94, 106)"
-    },
-    {
-        "glyph": "η",
-        "title": "eta",
-        "css_class": "noadic-function-button",
-        "color": "rgb(237, 94, 106)"
-    },
-    {
-        "glyph": "π",
-        "title": "pi",
-        "css_class": "noadic-function-button",
-        "color": "rgb(237, 94, 106)"
-    },
-    {
-        "glyph": "τ",
-        "title": "tau",
-        "css_class": "noadic-function-button",
-        "color": "rgb(237, 94, 106)"
-    },
-    {
-        "glyph": "∞",
-        "title": "infinity",
-        "css_class": "noadic-function-button",
-        "color": "rgb(237, 94, 106)"
-    },
-    {
-        "glyph": "~",
-        "title": "trace",
-        "css_class": "stack-function-button",
-        "color": "rgb(209, 218, 236)"
-    },
-    {
-        "glyph": "_",
-        "title": "strand",
-        "css_class": "misc-function-button",
-        "color": "rgba(255, 255, 255, 0.533)"
-    },
-    {
-        "glyph": "[]",
-        "title": "array",
-        "css_class": "misc-function-button",
-        "color": "rgb(209, 218, 236)"
-    },
-    {
-        "glyph": "{}",
-        "title": "box array",
-        "css_class": "misc-function-button",
-        "color": "rgb(209, 218, 236)"
-    },
-    {
-        "glyph": "()",
-        "title": "function",
-        "css_class": "misc-function-button",
-        "color": "rgb(209, 218, 236)"
-    },
-    {
-        "glyph": "¯",
-        "title": "negative (`)",
-        "css_class": "misc-function-button",
-        "color": "rgb(255, 136, 68)"
-    },
-    {
-        "glyph": "@",
-        "title": "character",
-        "css_class": "misc-function-button",
-        "color": "rgb(32, 249, 252)"
-    },
-    {
-        "glyph": "$",
-        "title": "format/multiline string",
-        "css_class": "misc-function-button",
-        "color": "rgb(32, 249, 252)"
-    },
-    {
-        "glyph": "\"",
-        "title": "string",
-        "css_class": "misc-function-button",
-        "color": "rgb(32, 249, 252)"
-    },
-    {
-        "glyph": "^",
-        "title": "terminate modifier",
-        "css_class": "misc-function-button",
-        "color": "rgb(209, 218, 236)"
-    },
-    {
-        "glyph": "←",
-        "title": "binding (=)",
-        "css_class": "misc-function-button",
-        "color": "rgb(209, 218, 236)"
-    },
-    {
-        "glyph": "|",
-        "title": "signature",
-        "css_class": "misc-function-button",
-        "color": "rgb(209, 218, 236)"
-    },
-    {
-        "glyph": "#",
-        "title": "comment",
-        "css_class": "misc-function-button",
-        "color": "rgb(136, 136, 136)"
-    }
-]
+const glyphs= 
+{
+  "absolute value": {
+    "glyph": "⌵",
+    "description": "Get the absolute value of a number",
+    "class": "code-font monadic-function-button"
+  },
+  "add": {
+    "glyph": "+",
+    "description": "Add values",
+    "class": "code-font dyadic-function-button"
+  },
+  "assert": {
+    "glyph": "⍤",
+    "description": "Throw an error if a condition is not met",
+    "class": "code-font dyadic-function-button"
+  },
+  "atangent": {
+    "glyph": "∠",
+    "description": "Take the arctangent of two numbers",
+    "class": "code-font dyadic-function-button"
+  },
+  "bind": {
+    "glyph": "'",
+    "description": "Compose two functions",
+    "class": "code-font modifier2-button"
+  },
+  "bits": {
+    "glyph": "⋯",
+    "description": "Encode an array as bits (big-endian)",
+    "class": "code-font monadic-function-button"
+  },
+  "both": {
+    "glyph": "∩",
+    "description": "Call a function on two sets of values",
+    "class": "code-font modifier1-button"
+  },
+  "box": {
+    "glyph": "□",
+    "description": "Turn an array into a box",
+    "class": "code-font monadic-function-button"
+  },
+  "bracket": {
+    "glyph": "⊓",
+    "description": "Call two functions on two distinct sets of values",
+    "class": "code-font modifier2-button"
+  },
+  "break": {
+    "glyph": "⎋",
+    "description": "Break out of a loop",
+    "class": "code-font monadic-function-button"
+  },
+  "call": {
+    "glyph": "!",
+    "description": "Call a function",
+    "class": "code-font variadic-function-button"
+  },
+  "ceiling": {
+    "glyph": "⌈",
+    "description": "Round to the nearest integer towards ∞",
+    "class": "code-font monadic-function-button"
+  },
+  "classify": {
+    "glyph": "⊛",
+    "description": "Assign a unique index to each unique element in an array",
+    "class": "code-font monadic-function-button"
+  },
+  "couple": {
+    "glyph": "⊟",
+    "description": "Combine two arrays as rows of a new array",
+    "class": "code-font dyadic-function-button"
+  },
+  "cross": {
+    "glyph": "⊠",
+    "description": "Apply a function to each combination of rows of two arrays",
+    "class": "code-font modifier1-button"
+  },
+  "deduplicate": {
+    "glyph": "⊝",
+    "description": "Remove duplicate elements from an array",
+    "class": "code-font monadic-function-button"
+  },
+  "deshape": {
+    "glyph": "♭",
+    "description": "Make an array 1-dimensional",
+    "class": "code-font monadic-function-button"
+  },
+  "dip": {
+    "glyph": "⊙",
+    "description": "Temporarily pop the top value off the stack and call a function",
+    "class": "code-font modifier1-button"
+  },
+  "distribute": {
+    "glyph": "∺",
+    "description": "Apply a function to a fixed value and each row of an array",
+    "class": "code-font modifier1-button"
+  },
+  "divide": {
+    "glyph": "÷",
+    "description": "Divide values",
+    "class": "code-font dyadic-function-button"
+  },
+  "drop": {
+    "glyph": "↘",
+    "description": "Drop the first n elements of an array",
+    "class": "code-font dyadic-function-button"
+  },
+  "duplicate": {
+    "glyph": ".",
+    "description": "Duplicate the top value on the stack",
+    "class": "code-font stack-function-button"
+  },
+  "each": {
+    "glyph": "∵",
+    "description": "Apply a function to each element of an array or arrays.",
+    "class": "code-font modifier1-button"
+  },
+  "equals": {
+    "glyph": "=",
+    "description": "Compare for equality",
+    "class": "code-font dyadic-function-button"
+  },
+  "eta": {
+    "glyph": "η",
+    "description": "The number of radians in a quarter circle",
+    "class": "code-font noadic-function-button"
+  },
+  "fall": {
+    "glyph": "⍖",
+    "description": "Get the indices into an array if it were sorted descending",
+    "class": "code-font monadic-function-button"
+  },
+  "fill": {
+    "glyph": "⬚",
+    "description": "Set the fill value for a function",
+    "class": "code-font modifier2-button"
+  },
+  "find": {
+    "glyph": "⌕",
+    "description": "Find the occurences of one array in another",
+    "class": "code-font dyadic-function-button"
+  },
+  "first": {
+    "glyph": "⊢",
+    "description": "Get the first row of an array",
+    "class": "code-font monadic-function-button"
+  },
+  "flip": {
+    "glyph": "∶",
+    "description": "Swap the top two values on the stack",
+    "class": "code-font stack-function-button"
+  },
+  "floor": {
+    "glyph": "⌊",
+    "description": "Round to the nearest integer towards ¯∞",
+    "class": "code-font monadic-function-button"
+  },
+  "fold": {
+    "glyph": "∧",
+    "description": "Apply a reducing function to an array with an initial value",
+    "class": "code-font modifier1-button"
+  },
+  "fork": {
+    "glyph": "⊃",
+    "description": "Call two functions on the same values",
+    "class": "code-font modifier2-button"
+  },
+  "gap": {
+    "glyph": "⋅",
+    "description": "Discard the top stack value then call a function",
+    "class": "code-font modifier1-button"
+  },
+  "greater or equal": {
+    "glyph": "≥",
+    "description": "Compare for greater than or equal",
+    "class": "code-font dyadic-function-button"
+  },
+  "greater than": {
+    "glyph": ">",
+    "description": "Compare for greater than",
+    "class": "code-font dyadic-function-button"
+  },
+  "group": {
+    "glyph": "⊕",
+    "description": "Group elements of an array into buckets by index",
+    "class": "code-font modifier1-button"
+  },
+  "identity": {
+    "glyph": "∘",
+    "description": "Do nothing",
+    "class": "code-font stack-function-button"
+  },
+  "if": {
+    "glyph": "?",
+    "description": "Call one of two functions based on a condition",
+    "class": "code-font modifier2-button"
+  },
+  "indexof": {
+    "glyph": "⊗",
+    "description": "Find the index of each row of one array in another",
+    "class": "code-font dyadic-function-button"
+  },
+  "infinity": {
+    "glyph": "∞",
+    "description": "The biggest number",
+    "class": "code-font noadic-function-button"
+  },
+  "invert": {
+    "glyph": "⍘",
+    "description": "Invert the behavior of a function",
+    "class": "code-font modifier1-button"
+  },
+  "join": {
+    "glyph": "⊂",
+    "description": "Append two arrays end-to-end",
+    "class": "code-font dyadic-function-button"
+  },
+  "keep": {
+    "glyph": "▽",
+    "description": "Discard or copy some rows of an array",
+    "class": "code-font dyadic-function-button"
+  },
+  "length": {
+    "glyph": "⧻",
+    "description": "Get the number of rows in an array",
+    "class": "code-font monadic-function-button"
+  },
+  "less or equal": {
+    "glyph": "≤",
+    "description": "Compare for less than or equal",
+    "class": "code-font dyadic-function-button"
+  },
+  "less than": {
+    "glyph": "<",
+    "description": "Compare for less than",
+    "class": "code-font dyadic-function-button"
+  },
+  "level": {
+    "glyph": "⍚",
+    "description": "Apply a function at a different array depth",
+    "class": "code-font modifier2-button"
+  },
+  "logarithm": {
+    "glyph": "ₙ",
+    "description": "Get the based logarithm of a number",
+    "class": "code-font dyadic-function-button"
+  },
+  "match": {
+    "glyph": "≅",
+    "description": "Check if two arrays are exactly the same",
+    "class": "code-font dyadic-function-button"
+  },
+  "maximum": {
+    "glyph": "↥",
+    "description": "Take the maximum of two arrays",
+    "class": "code-font dyadic-function-button"
+  },
+  "member": {
+    "glyph": "∊",
+    "description": "Check if each row of one array exists in another",
+    "class": "code-font dyadic-function-button"
+  },
+  "minimum": {
+    "glyph": "↧",
+    "description": "Take the minimum of two arrays",
+    "class": "code-font dyadic-function-button"
+  },
+  "modulus": {
+    "glyph": "◿",
+    "description": "Modulo values",
+    "class": "code-font dyadic-function-button"
+  },
+  "multiply": {
+    "glyph": "×",
+    "description": "Multiply values",
+    "class": "code-font dyadic-function-button"
+  },
+  "negate": {
+    "glyph": "¯",
+    "description": "Negate a number",
+    "class": "code-font monadic-function-button"
+  },
+  "not": {
+    "glyph": "¬",
+    "description": "Logical not",
+    "class": "code-font monadic-function-button"
+  },
+  "not equals": {
+    "glyph": "≠",
+    "description": "Compare for inequality",
+    "class": "code-font dyadic-function-button"
+  },
+  "over": {
+    "glyph": ",",
+    "description": "Duplicate the second-to-top value to the top of the stack",
+    "class": "code-font stack-function-button"
+  },
+  "partition": {
+    "glyph": "⊜",
+    "description": "Group elements of an array into buckets by sequential keys",
+    "class": "code-font modifier1-button"
+  },
+  "pi": {
+    "glyph": "π",
+    "description": "The ratio of a circle's circumference to its diameter",
+    "class": "code-font noadic-function-button"
+  },
+  "pick": {
+    "glyph": "⊡",
+    "description": "Index a row or elements from an array",
+    "class": "code-font dyadic-function-button"
+  },
+  "pop": {
+    "glyph": ";",
+    "description": "Discard the top stack value",
+    "class": "code-font stack-function-button"
+  },
+  "power": {
+    "glyph": "ⁿ",
+    "description": "Raise a value to a power",
+    "class": "code-font dyadic-function-button"
+  },
+  "random": {
+    "glyph": "⚂",
+    "description": "Generate a random number between 0 and 1",
+    "class": "code-font noadic-function-button"
+  },
+  "range": {
+    "glyph": "⇡",
+    "description": "Make an array of all natural numbers less than a number",
+    "class": "code-font monadic-function-button"
+  },
+  "recur": {
+    "glyph": "↬",
+    "description": "Call a function recursively",
+    "class": "code-font monadic-function-button"
+  },
+  "reduce": {
+    "glyph": "/",
+    "description": "Apply a reducing function to an array",
+    "class": "code-font modifier1-button"
+  },
+  "repeat": {
+    "glyph": "⍥",
+    "description": "Repeat a function a number of times",
+    "class": "code-font modifier1-button"
+  },
+  "reshape": {
+    "glyph": "↯",
+    "description": "Change the shape of an array",
+    "class": "code-font dyadic-function-button"
+  },
+  "reverse": {
+    "glyph": "⇌",
+    "description": "Reverse the rows of an array",
+    "class": "code-font monadic-function-button"
+  },
+  "rise": {
+    "glyph": "⍏",
+    "description": "Get the indices into an array if it were sorted ascending",
+    "class": "code-font monadic-function-button"
+  },
+  "rotate": {
+    "glyph": "↻",
+    "description": "Rotate the elements of an array by n",
+    "class": "code-font dyadic-function-button"
+  },
+  "round": {
+    "glyph": "⁅",
+    "description": "Round to the nearest integer",
+    "class": "code-font monadic-function-button"
+  },
+  "rows": {
+    "glyph": "≡",
+    "description": "Apply a function to each row of an array or arrays",
+    "class": "code-font modifier1-button"
+  },
+  "scan": {
+    "glyph": "\\",
+    "description": "Reduce, but keep intermediate values",
+    "class": "code-font modifier1-button"
+  },
+  "select": {
+    "glyph": "⊏",
+    "description": "Select multiple rows from an array",
+    "class": "code-font dyadic-function-button"
+  },
+  "shape": {
+    "glyph": "△",
+    "description": "Get the dimensions of an array",
+    "class": "code-font monadic-function-button"
+  },
+  "sign": {
+    "glyph": "±",
+    "description": "Numerical sign (1, ¯1, or 0)",
+    "class": "code-font monadic-function-button"
+  },
+  "sine": {
+    "glyph": "○",
+    "description": "Get the sine of a number",
+    "class": "code-font monadic-function-button"
+  },
+  "sqrt": {
+    "glyph": "√",
+    "description": "Take the square root of a number",
+    "class": "code-font monadic-function-button"
+  },
+  "subtract": {
+    "glyph": "-",
+    "description": "Subtract values",
+    "class": "code-font dyadic-function-button"
+  },
+  "table": {
+    "glyph": "⊞",
+    "description": "Apply a function to each combination of elements of two arrays",
+    "class": "code-font modifier1-button"
+  },
+  "take": {
+    "glyph": "↙",
+    "description": "Take the first n elements of an array",
+    "class": "code-font dyadic-function-button"
+  },
+  "tau": {
+    "glyph": "τ",
+    "description": "The ratio of a circle's circumference to its radius",
+    "class": "code-font noadic-function-button"
+  },
+  "trace": {
+    "glyph": "~",
+    "description": "Debug print the top value on the stack without popping it",
+    "class": "code-font stack-function-button"
+  },
+  "transpose": {
+    "glyph": "⍉",
+    "description": "Rotate the shape of an array",
+    "class": "code-font monadic-function-button trans"
+  },
+  "try": {
+    "glyph": "⍣",
+    "description": "Call a function and catch errors",
+    "class": "code-font modifier2-button"
+  },
+  "unbox": {
+    "glyph": "⊔",
+    "description": "Take an array out of a box",
+    "class": "code-font monadic-function-button"
+  },
+  "under": {
+    "glyph": "⍜",
+    "description": "Apply a function under another",
+    "class": "code-font modifier2-button"
+  },
+  "where": {
+    "glyph": "⊚",
+    "description": "Get indices where array values are not equal to zero",
+    "class": "code-font monadic-function-button"
+  },
+  "windows": {
+    "glyph": "◫",
+    "description": "The n-wise windows of an array",
+    "class": "code-font dyadic-function-button"
+  }
+}

--- a/webview_keypad/index.css
+++ b/webview_keypad/index.css
@@ -12,11 +12,17 @@ body{
     color:rgb(240, 249, 255);
     display:grid;
     grid-template-rows: auto 1fr auto;
-    
+
 }
 #tooltip-display{
     text-align: center;
     font-size: 1.3em;
+    font-weight: bold;
+}
+#tooltip-display-desc{
+    text-align: center;
+    font-size: 0.73em;
+    height: 2em;
 }
 #button-holder{
     display:flex;
@@ -24,18 +30,38 @@ body{
     padding: 0 0.5em;
     gap:0.3em;
     justify-content: center;
+    align-content: flex-start;
 }
 #button-holder > button{
     font-family:  "DejaVu Sans Mono", sans-serif;
     width:2em;
     max-height: 4em;
     font-size:inherit;
-    background-color: #19232d;
+    background-color: transparent;
     border-radius: 0.2em;
     border-width: 0;
 }
 #button-holder>button:hover{
     background-color: #0003;
+}
+
+.code-font {
+    color: #d1daec;
+}
+.noadic-function-button {
+    color: #ed5e6a;
+}
+.monadic-function-button {
+    color: #95d16a;
+}
+.dyadic-function-button {
+    color: #54b0fc;
+}
+.modifier1-button {
+    color: #f0c36f;
+}
+.modifier2-button {
+    color: #cc6be9;
 }
 .trans{
     background-image: linear-gradient(180deg, #5BCEFA 29%, #F5A9B8 29%, #F5A9B8 43%, #FFFFFF 43%, #FFFFFF 57%, #F5A9B8 57%, #F5A9B8 71%, #5BCEFA 71%);
@@ -46,6 +72,7 @@ body{
     -webkit-text-fill-color: transparent;
     -moz-text-fill-color: transparent;
 }
+
 .bar {
     padding:1em;
 }

--- a/webview_keypad/index.html
+++ b/webview_keypad/index.html
@@ -11,6 +11,7 @@
     <body>
         <div class="bar">
             <div id="tooltip-display">&nbsp;</div>
+            <div id="tooltip-display-desc">&nbsp;</div>
         </div>
         <div id="button-holder"></div>
         <div class="bar">

--- a/webview_keypad/main.js
+++ b/webview_keypad/main.js
@@ -9,22 +9,22 @@ try{
 let tooltip = document.querySelector("#tooltip-display");
 let tooltipDesc = document.querySelector("#tooltip-display-desc");
 
-for(let [k, v] of Object.entries(glyphs)){
+for(let glyph of glyphs){
     let button = document.createElement("button");
 
-    button.setAttribute("data-title", k);
+    button.setAttribute("data-title", glyph.name);
     button.addEventListener("click", ()=>
         vscode.postMessage({
             command:"write_glyph",
-            text:v.glyph,
+            text:glyph.glyph,
             name:button.attributes["data-title"].value
         })
     );
     button.addEventListener("mouseover", ()=>{
-        tooltip.innerHTML = k;
-        tooltipDesc.innerHTML = v.description;
+        tooltip.innerHTML = glyph.name;
+        tooltipDesc.innerHTML = glyph.description;
     });
-    button.innerHTML = `<div class="${v.class}">${v.glyph}</div>`;
+    button.innerHTML = `<div class="${glyph.class}">${glyph.glyph}</div>`;
     document.querySelector("#button-holder").appendChild(button);
 }
 

--- a/webview_keypad/main.js
+++ b/webview_keypad/main.js
@@ -7,34 +7,24 @@ try{
     vscode.postMessage = (...args)=>console.log("postMessage", ...args);
 }
 let tooltip = document.querySelector("#tooltip-display");
+let tooltipDesc = document.querySelector("#tooltip-display-desc");
 
-document.querySelector("#button-holder").addEventListener("mouseover",e=>{
-    if(e.target.attributes["data-title"]){
-        tooltip.innerHTML = e.target.attributes["data-title"].value
-    }
-});
-
-for(let glyph of glyphs){
+for(let [k, v] of Object.entries(glyphs)){
     let button = document.createElement("button");
-    
-    button.setAttribute("data-title", glyph.title);
-    button.setAttribute("data-ic", glyph.css_class);
-    button.addEventListener("pointerup", e=>
+
+    button.setAttribute("data-title", k);
+    button.addEventListener("click", ()=>
         vscode.postMessage({
             command:"write_glyph",
-            text:glyph.glyph,
-            name:e.target.attributes["data-title"].value
+            text:v.glyph,
+            name:button.attributes["data-title"].value
         })
-    )
-    if(glyph.title=="transpose"){
-        let div = document.createElement("div");
-        div.setAttribute("class", "trans");
-        div.innerText = glyph.glyph;
-        button.appendChild(div);
-    }else{
-        button.innerText = glyph.glyph;
-        button.setAttribute("style", `color:${glyph.color};`);
-    }
+    );
+    button.addEventListener("mouseover", ()=>{
+        tooltip.innerHTML = k;
+        tooltipDesc.innerHTML = v.description;
+    });
+    button.innerHTML = `<div class="${v.class}">${v.glyph}</div>`;
     document.querySelector("#button-holder").appendChild(button);
 }
 


### PR DESCRIPTION
Compared to #1 this one does a bit less but it also does a bit more. I'll just describe all that's changed.

![image](https://github.com/thehappycheese/uiua-keypad/assets/22648124/6d522bdd-c803-4ba5-b9dd-d9b102da58b6)

First of all the way the glyphs database is structured has changed. I'm aware of the fact that when you previously asked about a possible JSON endpoint for Uiua's functions no one answered. I joined the server recently and asked a similar question, and Kaikalii responded by creating a [Rust program](https://github.com/kaikalii/uiua-gen-functions-json) that does exactly what you're looking for. I [forked it](https://github.com/thekifake/uiua-gen-functions-json) and added more stuff -- namely, including class information in the glyph data as well as creating an automated batch script that does the job for you of generating the JSON array, converting it to a JavaScript file, and copying it into a directory of your choosing. You'll probably want to run this whenever Uiua updates.

This noticeably allows you to 1. get the glyphs even if the website introduces a breaking change that makes the current method of scanning Uiuapad obsolete, and 2. get any given glyph's description or any other value if you know how to get to it in Rust. So, hovering over a glyph now shows its one-line description of what it does.

Also I changed the event listeners for the buttons again. I'm not sure why they're implemented in the way that they are and I think what additional overhead and unnecessary complication it introduces, regardless of how small it is, should be changed to make it... better, maybe. It's entirely up to you whether you want to keep these changes to the event listeners if there's a specific reason they're used in the way that they're currently used.

Also, glyph colors are no longer hardcoded. They're determined by their classes instead, like in Uiuapad. If the suggestion at #2 tickles your fancy then changing `code-font` to use Uiua386 might be worth doing, but right now it still uses the default font for the keypad. Additionally glyph buttons have transparent backgrounds until hovered once again. This is just a preference thing, if you want it changed you can tell me.

That's pretty much it. If there's any changes you need made, let me know.